### PR TITLE
patch to catch events that tell us when to disable desktop

### DIFF
--- a/openbox/client.c
+++ b/openbox/client.c
@@ -71,6 +71,13 @@ typedef struct
 
 GList          *client_list             = NULL;
 
+
+// Albert - Boolean variable to tell us if we need to 
+// disable the desktop icons as input events start to be dispatched.
+// see startupnotify.c
+extern gboolean bDisableDesktop;
+
+
 static GSList  *client_destroy_notifies = NULL;
 static RrImage *client_default_icon     = NULL;
 
@@ -890,6 +897,15 @@ static gboolean client_can_steal_focus(ObClient *self,
                          "another desktop and no relatives are focused ");
             }
         }
+    }
+
+
+    // Albert - At this point we can decide wether a graphic object
+    // is allowed to acquire focus. Are we starting an app
+    // and the mouse hourglass is active?
+
+    if (bDisableDesktop == TRUE) {
+        ob_debug(">>> Mouse hourglass is active - DISABLING DESKTOP ICONS");
     }
 
     if (!steal)

--- a/openbox/screen.c
+++ b/openbox/screen.c
@@ -1845,12 +1845,24 @@ const Rect* screen_physical_area_primary(gboolean fixed)
 
 void screen_set_root_cursor(void)
 {
-    if (sn_app_starting())
+    int rc=0;
+
+    if (sn_app_starting()) {
+        /* Albert - disable desktop mouse / keyboard events */
+        rc = XGrabPointer (obt_display, obt_root(ob_screen),
+                           FALSE, 0, GrabModeAsync, GrabModeAsync, None,
+                           ob_cursor(OB_CURSOR_BUSYPOINTER), CurrentTime);
+        
         XDefineCursor(obt_display, obt_root(ob_screen),
                       ob_cursor(OB_CURSOR_BUSYPOINTER));
-    else
+    }
+    else {
+        /* Albert - re-enable desktop mouse / keyboard events */
+        rc = XUngrabPointer (obt_display, CurrentTime);
+
         XDefineCursor(obt_display, obt_root(ob_screen),
                       ob_cursor(OB_CURSOR_POINTER));
+    }
 }
 
 guint screen_find_monitor_point(guint x, guint y)


### PR DESCRIPTION
There are 2 main improvements in the original openbox code:
1. when the mouse pointer changes to hourglass we keep a global flag.
2. when openbox needs to decide wether focus can change, we know if the hourglass is active.

This change does not actually disable desktop icons yet.
